### PR TITLE
fix: disable compression bomb error

### DIFF
--- a/wd-hydrus-tagger/__main__.py
+++ b/wd-hydrus-tagger/__main__.py
@@ -6,6 +6,7 @@ from . import interrogate
 import hydrus_api
 from io import BytesIO
 
+Image.MAX_IMAGE_PIXELS = None
 
 @click.group()
 def cli():


### PR DESCRIPTION
## Bug:
process crashes when an image is too big.

## How can this be fixed:
By disabling the compression bomb check (https://stackoverflow.com/questions/51152059/pillow-in-python-wont-let-me-open-image-exceeds-limit)

## Error message (for context):
```bash
Traceback (most recent call last):
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.10_3.10.3056.0_x64__qbz5n2kfra8p0\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.10_3.10.3056.0_x64__qbz5n2kfra8p0\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\Code\python\wd-e621-hydrus-tagger\wd-hydrus-tagger\__main__.py", line 135, in <module>
    cli()
  File "C:\Code\python\wd-e621-hydrus-tagger\venv\lib\site-packages\click\core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "C:\Code\python\wd-e621-hydrus-tagger\venv\lib\site-packages\click\core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "C:\Code\python\wd-e621-hydrus-tagger\venv\lib\site-packages\click\core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "C:\Code\python\wd-e621-hydrus-tagger\venv\lib\site-packages\click\core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\Code\python\wd-e621-hydrus-tagger\venv\lib\site-packages\click\core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "C:\Code\python\wd-e621-hydrus-tagger\wd-hydrus-tagger\__main__.py", line 108, in evaluate_api_batch
    image = Image.open(image_bytes)
  File "C:\Code\python\wd-e621-hydrus-tagger\venv\lib\site-packages\PIL\Image.py", line 3268, in open
    im = _open_core(fp, filename, prefix, formats)
  File "C:\Code\python\wd-e621-hydrus-tagger\venv\lib\site-packages\PIL\Image.py", line 3255, in _open_core
    _decompression_bomb_check(im.size)
  File "C:\Code\python\wd-e621-hydrus-tagger\venv\lib\site-packages\PIL\Image.py", line 3164, in _decompression_bomb_check
    raise DecompressionBombError(msg)
PIL.Image.DecompressionBombError: Image size (250094136 pixels) exceeds limit of 178956970 pixels, could be decompression bomb DOS attack.
```